### PR TITLE
Make .paginate actually work with Rails 3.1

### DIFF
--- a/lib/will_paginate/finder.rb
+++ b/lib/will_paginate/finder.rb
@@ -79,7 +79,7 @@ module WillPaginate
           
           args << find_options
           # @options_from_last_find = nil
-          pager.replace(send(finder, *args) { |*a| yield(*a) if block_given? })
+          pager.replace(send(finder, *args).each { |*a| yield(*a) if block_given? })
           
           # magic counting for user convenience:
           pager.total_entries = wp_count(count_options, args, finder) unless pager.total_entries


### PR DESCRIPTION
Without it's 

```
 ruby-1.8.7-p352 :004 > Fileset.paginate(:order => "id", :page => nil)
      Fileset Load (0.5ms)  SELECT `filesets`.* FROM `filesets` 
 TypeError: can't convert nil into Array
          from /Users/eugene/.rvm/gems/ruby-1.8.7-p352/bundler/gems/will_paginate-e1676b5cec9e/lib/will_paginate/collection.rb:133:in `replace'
```

With it's

```
 ruby-1.8.7-p352 :001 > Fileset.paginate(:order => "id", :page => nil)
     Fileset Load (0.5ms)  SELECT `filesets`.* FROM `filesets` ORDER BY id LIMIT 30 OFFSET 0
 => [#<Fileset id: 1, name: "Solarized Light.dvtcolortheme", description: nil, ip: "127.0.0.1", user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) Appl..."
```

I think you can add it to the original pull request in the mislav repo
